### PR TITLE
MUS-249 Add TabIndentationPlugin and style fix

### DIFF
--- a/streamlit_lexical/frontend/src/StreamlitLexical.tsx
+++ b/streamlit_lexical/frontend/src/StreamlitLexical.tsx
@@ -26,6 +26,7 @@ import { HeadingNode, QuoteNode } from "@lexical/rich-text"
 import { CodeNode } from "@lexical/code"
 import { ListNode, ListItemNode } from "@lexical/list"
 import { ListPlugin } from "@lexical/react/LexicalListPlugin"
+import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin"
 import { LinkNode } from "@lexical/link"
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
 import { useEffect } from "react"
@@ -112,6 +113,7 @@ class StreamlitLexical extends StreamlitComponentBase<State, Props> {
               <AutoFocusPlugin />
               <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
               <ListPlugin />
+              <TabIndentationPlugin />
               {/* <TreeViewPlugin /> */}
               <OnChangePlugin onChange={this.handleEditorChange} />
               {/* <EditorUpdateListener /> */}

--- a/streamlit_lexical/frontend/src/styles.css
+++ b/streamlit_lexical/frontend/src/styles.css
@@ -100,6 +100,15 @@
   margin-bottom: 0;
 }
 
+/* Nested list item styling - removes double bullets */
+.editor-nested-listitem {
+  list-style: none;
+}
+
+.editor-nested-listitem::marker {
+  content: none;
+}
+
 .editor-input p + ul,
 .editor-input p + ol,
 .editor-input ul + p,


### PR DESCRIPTION
This allows for sub lists and fixes a styling issue that existed by default once I installed the plugin.

Tested using the example script in the project

**could use some help deploying this. I don't see any instructions but I know it needs to end up in CodeArtifact