### PR TITLE
Fix debounce race condition bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="streamlit_lexical",
-    version="1.3.1",
+    version="1.3.3",
     author="Ben F",
     author_email="ben@musubilabs.ai",
     description="Streamlit component that allows you to use Meta's Lexical rich text editor",

--- a/streamlit_lexical/frontend/src/StreamlitLexical.tsx
+++ b/streamlit_lexical/frontend/src/StreamlitLexical.tsx
@@ -174,8 +174,8 @@ class StreamlitLexical extends StreamlitComponentBase<State, Props> {
   public state: State = {
     editorState: "",
   }
-  // track the markdown value to prevent unnecessary updates
   private markdownRef = { current: this.props.args.value }
+  private sentValues: string[] = [this.props.args.value]
 
   private editorConfig = {
     namespace: `MyStreamlitRichTextEditor-${this.props.args.key}`,
@@ -217,7 +217,7 @@ class StreamlitLexical extends StreamlitComponentBase<State, Props> {
           <EditorContentUpdater
             content={args.value}
             overwrite={args.overwrite}
-            currentMarkdown={this.markdownRef.current}
+            sentValues={this.sentValues}
           />
           <div className="editor-container">
             <ToolbarPlugin />
@@ -260,6 +260,10 @@ class StreamlitLexical extends StreamlitComponentBase<State, Props> {
 
   private debouncedSetComponentValue = debounce((value: string) => {
     this.markdownRef.current = value
+    this.sentValues.push(value)
+    if (this.sentValues.length > 20) {
+      this.sentValues = this.sentValues.slice(-10)
+    }
     Streamlit.setComponentValue(value)
   }, this.props.args.debounce)
 }
@@ -267,30 +271,33 @@ class StreamlitLexical extends StreamlitComponentBase<State, Props> {
 function EditorContentUpdater({
   content,
   overwrite,
-  currentMarkdown,
+  sentValues,
 }: {
   content: string
   overwrite: boolean
-  currentMarkdown: string
+  sentValues: string[]
 }) {
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
-    if (content === currentMarkdown) {
+    const idx = sentValues.indexOf(content)
+    if (idx !== -1) {
+      sentValues.splice(0, idx + 1)
       return
     }
+
     editor.update(() => {
       const root = $getRoot()
-      // Only set content if root is empty or overwrite is true
       if (root.getTextContent() === "" || overwrite) {
         root.clear()
         $convertFromMarkdownString(content, TRANSFORMERS, undefined, true)
         $splitMergedListItems()
-        // Clear history to prevent undo to empty state
         editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined)
       }
     })
-  }, [editor, content, overwrite, currentMarkdown])
+    sentValues.length = 0
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, content, overwrite])
 
   return null
 }


### PR DESCRIPTION
## The Problem

In production, while editing a long document in the Lexical rich text editor, the cursor suddenly jumps to the top of the editor and subsequent keystrokes are inserted at the beginning of the document instead of where the user was typing. The scroll position also resets to the top.

This only occurs at a "specific typing frequency" — typing in bursts with brief pauses between them.

## Root Cause

A race condition between the component's debounced `setComponentValue` calls and Streamlit's fragment rerun cycle.

### How Streamlit components communicate

1. User types → Lexical's `OnChangePlugin` fires `handleEditorChange`
2. The handler converts the editor state to Markdown and passes it to a debounced function (300ms)
3. When the debounce fires, two things happen atomically:
    - `markdownRef.current` is updated to the new Markdown string
    - `Streamlit.setComponentValue(markdown)` sends the value to the Streamlit server
4. Streamlit stores the value in `session_state[key]` and triggers a fragment rerun
5. During the rerun, the Python code reads `session_state[key]` and passes it back as the `value` prop
6. The component's `EditorContentUpdater` receives the new `value` prop and compares it to `markdownRef.current` — if they match, it's recognized as an echo of the component's own edit and skipped

### Where it breaks

During a fragment rerun, Streamlit **deregisters the component instance** from its internal `ComponentRegistry`. If the debounce fires during this deregistered window, the `setComponentValue` message has no registered recipient:

```
Received component message for unregistered ComponentInstance!
{isStreamlitMessage: true, type: 'streamlit:setComponentValue', value: '...', dataType: 'json'}
```

The value is **dropped** — it never reaches `session_state`. Meanwhile, `markdownRef.current` WAS updated (since that happens before the `setComponentValue` call). When the rerun eventually completes and sends props back:

- `content` (from props) = the **older** value from `session_state` (e.g., `v1`)
- `markdownRef.current` = the **newer** value from the dropped debounce (e.g., `v2`)
- `v1 !== v2` → the guard fails → `EditorContentUpdater` calls `root.clear()` + `$convertFromMarkdownString()`, which destroys the entire Lexical editor state and rebuilds it from the stale Markdown
- Cursor position, selection, and scroll are all reset to the top

### Why it doesn't happen on localhost

On localhost, the Streamlit server roundtrip (WebSocket message → server rerun → response) is near-instant (<50ms). The deregistered window is so short that the debounce almost never fires during it.

In production, network latency + server processing time stretches the roundtrip to 200–1000ms, making the deregistered window much wider and easy to hit with normal typing patterns.

## How to Reproduce on Localhost

Add a `time.sleep()` before the `streamlit_lexical()` call in the fragment to simulate production latency:

```python
import time

# Inside the fragment, right before the streamlit_lexical() call:
time.sleep(1.5)  # Simulate prod roundtrip latency
streamlit_lexical(
    value=lexical_value,
    debounce=300,
    key=...,
)
```

Then:

1. Open the Manage Policies page
2. Select a policy with a long document
3. Scroll to the bottom of the Rich Text editor
4. Type a few characters, pause for ~300ms (long enough for the debounce to fire), then type a few more
5. Repeat this burst-pause-burst pattern — the component will stay "stale" (dimmed/gray)
6. When it finally un-grays, the cursor jumps to the top

The key insight: if you maintain the right typing cadence, the component stays gray indefinitely because each debounce triggers a new rerun before the previous one completes. When you finally pause long enough for a rerun to finish, it delivers stale props and the overwrite triggers.

## The Fix

Replace the single-value `markdownRef` comparison with a **queue of all recently sent values** (`sentValues`). This allows the component to recognize echoes of ANY previously sent value, not just the most recent one.

### Changes to `StreamlitLexical.tsx`

**1. Track all sent values in the class:**

```tsx
private sentValues: string[] = [this.props.args.value]
```

**2. Push to the queue on every debounce fire:**

```tsx
private debouncedSetComponentValue = debounce((value: string) => {
  this.markdownRef.current = value
  this.sentValues.push(value)
  if (this.sentValues.length > 20) {
    this.sentValues = this.sentValues.slice(-10)
  }
  Streamlit.setComponentValue(value)
}, this.props.args.debounce)
```

**3. Check the queue in `EditorContentUpdater` instead of comparing against `currentMarkdown`:**

```tsx
function EditorContentUpdater({ content, overwrite, sentValues }) {
  const [editor] = useLexicalComposerContext()

  useEffect(() => {
    const idx = sentValues.indexOf(content)
    if (idx !== -1) {
      // Recognized as an echo — discard it and all older entries
      sentValues.splice(0, idx + 1)
      return
    }

    // Not an echo — this is a genuine external update (e.g., policy switch)
    editor.update(() => {
      const root = $getRoot()
      if (root.getTextContent() === "" || overwrite) {
        root.clear()
        $convertFromMarkdownString(content, TRANSFORMERS, undefined, true)
        $splitMergedListItems()
        editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined)
      }
    })
    sentValues.length = 0
  }, [editor, content, overwrite])

  return null
}
```

### Why a list of sent values fixes it

The old code had a single variable (`markdownRef.current`) that only remembered the **last** value sent. The problem is that multiple values can be in-flight simultaneously, and the one that arrives as props might not be the last one sent.

Concrete example:

```
Time 0.0s: User types "hello"
Time 0.3s: Debounce fires → sends "hello" → markdownRef = "hello"
Time 0.5s: User types "hello world"
Time 0.8s: Debounce fires → sends "hello world" → markdownRef = "hello world"
Time 1.2s: Streamlit responds with props from the FIRST send: content = "hello"
```

**Old code** (single ref):

- Compares `content ("hello") === markdownRef.current ("hello world")` → **not equal**
- Concludes this must be an external update → overwrites the editor → cursor jumps

It can't tell the difference between "this is my own old value echoing back" and "the Python code intentionally pushed new content (like a policy switch)." Both look the same: `content !== markdownRef.current`.

**New code** (list):

- `sentValues = ["hello", "hello world"]`
- Checks `sentValues.indexOf("hello")` → **found at index 0**
- Concludes this is an echo → skips the overwrite → cursor stays put
- Cleans up: removes `"hello"` (and anything older) from the list

When the user actually switches policies, the Python code sends a completely new value that was never typed in the editor. That value won't be in `sentValues`, so it correctly gets treated as an external update and applied.

The list is essentially giving the component **memory** — it can recognize its own values coming back, even if they arrive out of order or after newer values have already been sent.

### Additional details

- The queue is bounded at 20 entries to prevent unbounded memory growth
- On external updates, the queue is cleared since those values are no longer relevant

### What it doesn't fix

The `Received component message for unregistered ComponentInstance!` console warning will still appear. This is a Streamlit framework behavior during fragment reruns that we can't control from the component side. The fix prevents the **consequence** (cursor jump) but not the warning itself.